### PR TITLE
Replace uppercase DBT to dbt

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 ## What is Quary?
 
-Quary enables teams to model, test and deploy data transformations. This core is a fast (30x faster than DBT to be precise!) and lightweight SQL transformation engine written in Rust.
+Quary enables teams to model, test and deploy data transformations. This core is a fast (30x faster than dbt to be precise!) and lightweight SQL transformation engine written in Rust.
 
 - Visit [our website](https://www.quary.dev) to learn more
 - Visit [our documentation](https://www.quary.dev/docs) to learn how to use Quary


### PR DESCRIPTION
I've updated the capitalization from DBT to dbt. When it's all caps, DBT refers to Dialectical Behavior Therapy but in lowercase, dbt is about data build tool.