### PR TITLE
feat: split snapshot generate to isolate query component

### DIFF
--- a/rust/core/src/database_bigquery.rs
+++ b/rust/core/src/database_bigquery.rs
@@ -1,4 +1,6 @@
-use crate::databases::{base_for_seeds_create_table_specifying_text_type, DatabaseQueryGenerator};
+use crate::databases::{
+    base_for_seeds_create_table_specifying_text_type, DatabaseQueryGenerator, SnapshotGenerator,
+};
 use sqlinference::dialect::Dialect;
 
 #[derive(Debug, Clone)]
@@ -66,6 +68,8 @@ impl DatabaseQueryGenerator for DatabaseQueryGeneratorBigQuery {
         format!("`{}`", name)
     }
 }
+
+impl SnapshotGenerator for DatabaseQueryGeneratorBigQuery {}
 
 #[cfg(test)]
 mod tests {

--- a/rust/core/src/database_postgres.rs
+++ b/rust/core/src/database_postgres.rs
@@ -1,4 +1,6 @@
-use crate::databases::{base_for_seeds_create_table_specifying_text_type, DatabaseQueryGenerator};
+use crate::databases::{
+    base_for_seeds_create_table_specifying_text_type, DatabaseQueryGenerator, SnapshotGenerator,
+};
 use chrono::{DateTime, Utc};
 use quary_proto::snapshot::snapshot_strategy::StrategyType;
 use sqlinference::dialect::Dialect;
@@ -113,69 +115,6 @@ impl DatabaseQueryGenerator for DatabaseQueryGeneratorPostgres {
         base_for_seeds_create_table_specifying_text_type("TEXT", &table_name, columns)
     }
 
-    fn generate_snapshot_sql(
-        &self,
-        path: &str,
-        templated_select: &str,
-        unique_key: &str,
-        strategy: &StrategyType,
-        table_exists: Option<bool>,
-    ) -> Result<Vec<String>, String> {
-        assert_eq!(
-            table_exists, None,
-            "table_exists is not necessary for Postgres snapshots."
-        );
-        match strategy {
-            StrategyType::Timestamp(timestamp) => {
-                let updated_at = &timestamp.updated_at;
-                let now = self.get_now();
-
-                let create_table_sql = format!(
-                    "CREATE TABLE IF NOT EXISTS {path} AS (
-                        SELECT
-                            ts.*,
-                            {now} AS quary_valid_from,
-                            CAST(NULL AS TIMESTAMP WITH TIME ZONE) AS quary_valid_to,
-                            MD5(CAST(CONCAT({unique_key}, CAST({updated_at} AS TEXT)) AS TEXT)) AS quary_scd_id
-                        FROM ({templated_select}) AS ts
-                    )"
-                );
-
-                let update_sql = format!(
-                    "UPDATE {path} AS target
-                    SET quary_valid_to = source.quary_valid_from
-                    FROM (
-                        SELECT
-                            ts.*,
-                            {now} AS quary_valid_from,
-                            MD5(CAST(CONCAT({unique_key}, CAST({updated_at} AS TEXT)) AS TEXT)) AS quary_scd_id
-                        FROM ({templated_select}) AS ts
-                    ) AS source
-                    WHERE target.{unique_key} = source.{unique_key}
-                        AND target.quary_valid_to IS NULL
-                        AND CAST(source.{updated_at} AS TIMESTAMP) > CAST(target.{updated_at} AS TIMESTAMP)"
-                );
-
-                let insert_sql = format!(
-                    "INSERT INTO {path}
-                    SELECT
-                        *,
-                        {now} AS quary_valid_from,
-                        NULL AS quary_valid_to,
-                        MD5(CAST(CONCAT({unique_key}, CAST({updated_at} AS TEXT)) AS TEXT)) AS quary_scd_id
-                    FROM ({templated_select}) AS source
-                    WHERE NOT EXISTS (
-                        SELECT 1
-                        FROM {path} AS target
-                        WHERE target.quary_scd_id = MD5(CAST(CONCAT(source.{unique_key}, CAST(source.{updated_at} AS TEXT)) AS TEXT))
-                    )"
-                );
-
-                Ok(vec![create_table_sql, update_sql, insert_sql])
-            }
-        }
-    }
-
     fn return_full_path_requirement(&self, table_name: &str) -> String {
         format!("{}.{}", self.schema, table_name)
     }
@@ -218,6 +157,90 @@ impl DatabaseQueryGenerator for DatabaseQueryGeneratorPostgres {
 
     fn database_name_wrapper(&self, name: &str) -> String {
         name.to_string()
+    }
+}
+
+impl SnapshotGenerator for DatabaseQueryGeneratorPostgres {
+    fn generate_snapshot_sql(
+        &self,
+        path: &str,
+        templated_select: &str,
+        unique_key: &str,
+        strategy: &StrategyType,
+        table_exists: Option<bool>,
+    ) -> Result<Vec<String>, String> {
+        assert_eq!(
+            table_exists, None,
+            "table_exists is not necessary for Postgres snapshots."
+        );
+        let snapshot_query =
+            self.generate_snapshot_query(templated_select, unique_key, strategy)?;
+        match strategy {
+            StrategyType::Timestamp(timestamp) => {
+                let updated_at = &timestamp.updated_at;
+                let now = self.get_now();
+
+                let create_table_sql = format!(
+                    "CREATE TABLE IF NOT EXISTS {path} AS (
+                       {snapshot_query}
+                    )"
+                );
+
+                let update_sql = format!(
+                    "UPDATE {path} AS target
+                    SET quary_valid_to = source.quary_valid_from
+                    FROM (
+                        SELECT
+                            ts.*,
+                            {now} AS quary_valid_from,
+                            MD5(CAST(CONCAT({unique_key}, CAST({updated_at} AS TEXT)) AS TEXT)) AS quary_scd_id
+                        FROM ({templated_select}) AS ts
+                    ) AS source
+                    WHERE target.{unique_key} = source.{unique_key}
+                        AND target.quary_valid_to IS NULL
+                        AND CAST(source.{updated_at} AS TIMESTAMP) > CAST(target.{updated_at} AS TIMESTAMP)"
+                );
+
+                let insert_sql = format!(
+                    "INSERT INTO {path}
+                    SELECT
+                        *,
+                        {now} AS quary_valid_from,
+                        NULL AS quary_valid_to,
+                        MD5(CAST(CONCAT({unique_key}, CAST({updated_at} AS TEXT)) AS TEXT)) AS quary_scd_id
+                    FROM ({templated_select}) AS source
+                    WHERE NOT EXISTS (
+                        SELECT 1
+                        FROM {path} AS target
+                        WHERE target.quary_scd_id = MD5(CAST(CONCAT(source.{unique_key}, CAST(source.{updated_at} AS TEXT)) AS TEXT))
+                    )"
+                );
+
+                Ok(vec![create_table_sql, update_sql, insert_sql])
+            }
+        }
+    }
+
+    fn generate_snapshot_query(
+        &self,
+        templated_select: &str,
+        unique_key: &str,
+        strategy: &StrategyType,
+    ) -> Result<String, String> {
+        match strategy {
+            StrategyType::Timestamp(timestamp) => {
+                let updated_at = &timestamp.updated_at;
+                let now = self.get_now();
+                Ok(format!(
+                    "SELECT
+                        ts.*,
+                        {now} AS quary_valid_from,
+                        CAST(NULL AS TIMESTAMP WITH TIME ZONE) AS quary_valid_to,
+                        MD5(CAST(CONCAT({unique_key}, CAST({updated_at} AS TEXT)) AS TEXT)) AS quary_scd_id
+                    FROM ({templated_select}) AS ts"
+                ))
+            }
+        }
     }
 }
 

--- a/rust/core/src/database_redshift.rs
+++ b/rust/core/src/database_redshift.rs
@@ -1,4 +1,6 @@
-use crate::databases::{base_for_seeds_create_table_specifying_text_type, DatabaseQueryGenerator};
+use crate::databases::{
+    base_for_seeds_create_table_specifying_text_type, DatabaseQueryGenerator, SnapshotGenerator,
+};
 use chrono::{DateTime, Utc};
 use quary_proto::snapshot::snapshot_strategy::StrategyType;
 use sqlinference::dialect::Dialect;
@@ -113,6 +115,52 @@ impl DatabaseQueryGenerator for DatabaseQueryGeneratorRedshift {
         base_for_seeds_create_table_specifying_text_type("TEXT", &table_name, columns)
     }
 
+    fn return_full_path_requirement(&self, table_name: &str) -> String {
+        format!("{}.{}", self.schema, table_name)
+    }
+
+    fn return_name_from_full_path<'a>(&self, full_path: &'a str) -> Result<&'a str, String> {
+        let split = full_path.split('.').collect::<Vec<&str>>();
+        match split.as_slice() {
+            [schema, table_name] => {
+                if schema == &self.schema {
+                    Ok(table_name)
+                } else {
+                    Err(format!(
+                        "Schema {} does not match expected value {}",
+                        schema, self.schema
+                    ))
+                }
+            }
+            _ => Err(format!(
+                "Table name {} does not contain the expected schema",
+                full_path
+            )),
+        }
+    }
+
+    fn automatic_cache_sql_create_statement(
+        &self,
+        model: &str,
+        model_cache_name: &str,
+    ) -> Vec<String> {
+        vec![format!(
+            "CREATE OR REPLACE VIEW {} AS SELECT * FROM {}",
+            self.return_full_path_requirement(model_cache_name),
+            self.return_full_path_requirement(model)
+        )]
+    }
+
+    fn get_dialect(&self) -> &Dialect {
+        &Dialect::Postgres
+    }
+
+    fn database_name_wrapper(&self, name: &str) -> String {
+        name.to_string()
+    }
+}
+
+impl SnapshotGenerator for DatabaseQueryGeneratorRedshift {
     fn generate_snapshot_sql(
         &self,
         path: &str,
@@ -183,48 +231,26 @@ impl DatabaseQueryGenerator for DatabaseQueryGeneratorRedshift {
         }
     }
 
-    fn return_full_path_requirement(&self, table_name: &str) -> String {
-        format!("{}.{}", self.schema, table_name)
-    }
-
-    fn return_name_from_full_path<'a>(&self, full_path: &'a str) -> Result<&'a str, String> {
-        let split = full_path.split('.').collect::<Vec<&str>>();
-        match split.as_slice() {
-            [schema, table_name] => {
-                if schema == &self.schema {
-                    Ok(table_name)
-                } else {
-                    Err(format!(
-                        "Schema {} does not match expected value {}",
-                        schema, self.schema
-                    ))
-                }
-            }
-            _ => Err(format!(
-                "Table name {} does not contain the expected schema",
-                full_path
-            )),
-        }
-    }
-
-    fn automatic_cache_sql_create_statement(
+    fn generate_snapshot_query(
         &self,
-        model: &str,
-        model_cache_name: &str,
-    ) -> Vec<String> {
-        vec![format!(
-            "CREATE OR REPLACE VIEW {} AS SELECT * FROM {}",
-            self.return_full_path_requirement(model_cache_name),
-            self.return_full_path_requirement(model)
-        )]
-    }
-
-    fn get_dialect(&self) -> &Dialect {
-        &Dialect::Postgres
-    }
-
-    fn database_name_wrapper(&self, name: &str) -> String {
-        name.to_string()
+        templated_select: &str,
+        unique_key: &str,
+        strategy: &StrategyType,
+    ) -> Result<String, String> {
+        match strategy {
+            StrategyType::Timestamp(timestamp) => {
+                let updated_at = &timestamp.updated_at;
+                let now = self.get_now();
+                Ok(format!(
+                    "SELECT
+                        ts.*,
+                        {now} AS quary_valid_from,
+                        CAST(NULL AS TIMESTAMP WITH TIME ZONE) AS quary_valid_to,
+                        MD5(CAST(CONCAT({unique_key}, CAST({updated_at} AS TEXT)) AS TEXT)) AS quary_scd_id
+                    FROM ({templated_select}) AS ts"
+                ))
+            }
+        }
     }
 }
 

--- a/rust/core/src/database_snowflake.rs
+++ b/rust/core/src/database_snowflake.rs
@@ -1,4 +1,6 @@
-use crate::databases::{base_for_seeds_create_table_specifying_text_type, DatabaseQueryGenerator};
+use crate::databases::{
+    base_for_seeds_create_table_specifying_text_type, DatabaseQueryGenerator, SnapshotGenerator,
+};
 use quary_proto::snapshot::snapshot_strategy::StrategyType;
 use sqlinference::dialect::Dialect;
 
@@ -82,65 +84,6 @@ impl DatabaseQueryGenerator for DatabaseQueryGeneratorSnowflake {
         base_for_seeds_create_table_specifying_text_type("STRING", table_name.as_str(), columns)
     }
 
-    fn generate_snapshot_sql(
-        &self,
-        path: &str,
-        templated_select: &str,
-        unique_key: &str,
-        strategy: &StrategyType,
-        table_exists: Option<bool>,
-    ) -> Result<Vec<String>, String> {
-        assert_eq!(
-            table_exists, None,
-            "table_exists is not necessary for Snowflake snapshots."
-        );
-        match strategy {
-            StrategyType::Timestamp(timestamp) => {
-                let updated_at = &timestamp.updated_at;
-                let create_table_sql = format!(
-                    "CREATE TABLE IF NOT EXISTS {path} AS (
-                        SELECT
-                            *,
-                            CURRENT_TIMESTAMP() AS quary_valid_from,
-                            NULL AS quary_valid_to,
-                            MD5(CONCAT({unique_key}, CAST({updated_at} AS VARCHAR))) AS quary_scd_id
-                        FROM ({templated_select})
-                    )"
-                );
-                let update_sql = format!(
-                    "MERGE INTO {path} AS target
-                    USING (
-                        SELECT
-                            *,
-                            CURRENT_TIMESTAMP() AS quary_valid_from,
-                            MD5(CONCAT({unique_key}, CAST({updated_at} AS VARCHAR))) AS quary_scd_id
-                        FROM ({templated_select})
-                    ) AS source
-                    ON target.{unique_key} = source.{unique_key}
-                    WHEN MATCHED AND target.quary_valid_to IS NULL AND source.{updated_at} > target.{updated_at}
-                    THEN UPDATE SET
-                        quary_valid_to = source.quary_valid_from,
-                        {updated_at} = source.{updated_at}"
-                );
-                let insert_sql = format!(
-                    "INSERT INTO {path}
-                    SELECT
-                        *,
-                        CURRENT_TIMESTAMP() AS quary_valid_from,
-                        NULL AS quary_valid_to,
-                        MD5(CONCAT({unique_key}, CAST({updated_at} AS VARCHAR))) AS quary_scd_id
-                    FROM ({templated_select}) AS source
-                    WHERE NOT EXISTS (
-                        SELECT 1
-                        FROM {path} AS target
-                        WHERE target.quary_scd_id = MD5(CONCAT(source.{unique_key}, CAST(source.{updated_at} AS VARCHAR)))
-                    )"
-                );
-                Ok(vec![create_table_sql, update_sql, insert_sql])
-            }
-        }
-    }
-
     fn return_full_path_requirement(&self, table_name: &str) -> String {
         format!("{}.{}.{}", self.database, self.schema, table_name)
     }
@@ -183,6 +126,85 @@ impl DatabaseQueryGenerator for DatabaseQueryGeneratorSnowflake {
 
     fn database_name_wrapper(&self, name: &str) -> String {
         name.to_string()
+    }
+}
+
+impl SnapshotGenerator for DatabaseQueryGeneratorSnowflake {
+    fn generate_snapshot_sql(
+        &self,
+        path: &str,
+        templated_select: &str,
+        unique_key: &str,
+        strategy: &StrategyType,
+        table_exists: Option<bool>,
+    ) -> Result<Vec<String>, String> {
+        assert_eq!(
+            table_exists, None,
+            "table_exists is not necessary for Snowflake snapshots."
+        );
+        let snapshot_query =
+            self.generate_snapshot_query(templated_select, unique_key, strategy)?;
+        match strategy {
+            StrategyType::Timestamp(timestamp) => {
+                let updated_at = &timestamp.updated_at;
+                let create_table_sql = format!(
+                    "CREATE TABLE IF NOT EXISTS {path} AS (
+                      {snapshot_query}
+                    )"
+                );
+                let update_sql = format!(
+                    "MERGE INTO {path} AS target
+                    USING (
+                        SELECT
+                            *,
+                            CURRENT_TIMESTAMP() AS quary_valid_from,
+                            MD5(CONCAT({unique_key}, CAST({updated_at} AS VARCHAR))) AS quary_scd_id
+                        FROM ({templated_select})
+                    ) AS source
+                    ON target.{unique_key} = source.{unique_key}
+                    WHEN MATCHED AND target.quary_valid_to IS NULL AND source.{updated_at} > target.{updated_at}
+                    THEN UPDATE SET
+                        quary_valid_to = source.quary_valid_from,
+                        {updated_at} = source.{updated_at}"
+                );
+                let insert_sql = format!(
+                    "INSERT INTO {path}
+                    SELECT
+                        *,
+                        CURRENT_TIMESTAMP() AS quary_valid_from,
+                        NULL AS quary_valid_to,
+                        MD5(CONCAT({unique_key}, CAST({updated_at} AS VARCHAR))) AS quary_scd_id
+                    FROM ({templated_select}) AS source
+                    WHERE NOT EXISTS (
+                        SELECT 1
+                        FROM {path} AS target
+                        WHERE target.quary_scd_id = MD5(CONCAT(source.{unique_key}, CAST(source.{updated_at} AS VARCHAR)))
+                    )"
+                );
+                Ok(vec![create_table_sql, update_sql, insert_sql])
+            }
+        }
+    }
+
+    fn generate_snapshot_query(
+        &self,
+        templated_select: &str,
+        unique_key: &str,
+        strategy: &StrategyType,
+    ) -> Result<String, String> {
+        match strategy {
+            StrategyType::Timestamp(timestamp) => {
+                let updated_at = &timestamp.updated_at;
+                Ok(format!(
+                    "SELECT
+                        *,
+                        CURRENT_TIMESTAMP() AS quary_valid_from,
+                        NULL AS quary_valid_to,
+                        MD5(CONCAT({unique_key}, CAST({updated_at} AS VARCHAR))) AS quary_scd_id
+                    FROM ({templated_select})"
+                ))
+            }
+        }
     }
 }
 
@@ -325,6 +347,6 @@ mod tests {
             .generate_snapshot_sql(path, templated_select, unique_key, &strategy, None)
             .unwrap();
 
-        assert_eq!(result.iter().map(|s| s.as_str()).collect::<Vec<&str>>(), vec!["CREATE TABLE IF NOT EXISTS mytable AS (\n                        SELECT\n                            *,\n                            CURRENT_TIMESTAMP() AS quary_valid_from,\n                            NULL AS quary_valid_to,\n                            MD5(CONCAT(id, CAST(updated_at AS VARCHAR))) AS quary_scd_id\n                        FROM (SELECT * FROM mytable)\n                    )", "MERGE INTO mytable AS target\n                    USING (\n                        SELECT\n                            *,\n                            CURRENT_TIMESTAMP() AS quary_valid_from,\n                            MD5(CONCAT(id, CAST(updated_at AS VARCHAR))) AS quary_scd_id\n                        FROM (SELECT * FROM mytable)\n                    ) AS source\n                    ON target.id = source.id\n                    WHEN MATCHED AND target.quary_valid_to IS NULL AND source.updated_at > target.updated_at\n                    THEN UPDATE SET\n                        quary_valid_to = source.quary_valid_from,\n                        updated_at = source.updated_at", "INSERT INTO mytable\n                    SELECT\n                        *,\n                        CURRENT_TIMESTAMP() AS quary_valid_from,\n                        NULL AS quary_valid_to,\n                        MD5(CONCAT(id, CAST(updated_at AS VARCHAR))) AS quary_scd_id\n                    FROM (SELECT * FROM mytable) AS source\n                    WHERE NOT EXISTS (\n                        SELECT 1\n                        FROM mytable AS target\n                        WHERE target.quary_scd_id = MD5(CONCAT(source.id, CAST(source.updated_at AS VARCHAR)))\n                    )"]);
+        assert_eq!(result.iter().map(|s| s.as_str()).collect::<Vec<&str>>(), vec!["CREATE TABLE IF NOT EXISTS mytable AS (\n                      SELECT\n                        *,\n                        CURRENT_TIMESTAMP() AS quary_valid_from,\n                        NULL AS quary_valid_to,\n                        MD5(CONCAT(id, CAST(updated_at AS VARCHAR))) AS quary_scd_id\n                    FROM (SELECT * FROM mytable)\n                    )", "MERGE INTO mytable AS target\n                    USING (\n                        SELECT\n                            *,\n                            CURRENT_TIMESTAMP() AS quary_valid_from,\n                            MD5(CONCAT(id, CAST(updated_at AS VARCHAR))) AS quary_scd_id\n                        FROM (SELECT * FROM mytable)\n                    ) AS source\n                    ON target.id = source.id\n                    WHEN MATCHED AND target.quary_valid_to IS NULL AND source.updated_at > target.updated_at\n                    THEN UPDATE SET\n                        quary_valid_to = source.quary_valid_from,\n                        updated_at = source.updated_at", "INSERT INTO mytable\n                    SELECT\n                        *,\n                        CURRENT_TIMESTAMP() AS quary_valid_from,\n                        NULL AS quary_valid_to,\n                        MD5(CONCAT(id, CAST(updated_at AS VARCHAR))) AS quary_scd_id\n                    FROM (SELECT * FROM mytable) AS source\n                    WHERE NOT EXISTS (\n                        SELECT 1\n                        FROM mytable AS target\n                        WHERE target.quary_scd_id = MD5(CONCAT(source.id, CAST(source.updated_at AS VARCHAR)))\n                    )"]);
     }
 }

--- a/rust/core/src/database_sqlite.rs
+++ b/rust/core/src/database_sqlite.rs
@@ -1,4 +1,4 @@
-use crate::databases::DatabaseQueryGenerator;
+use crate::databases::{DatabaseQueryGenerator, SnapshotGenerator};
 use sqlinference::dialect::Dialect;
 
 #[derive(Debug, Default)]
@@ -47,6 +47,8 @@ impl DatabaseQueryGenerator for DatabaseQueryGeneratorSqlite {
         format!("`{}`", name)
     }
 }
+
+impl SnapshotGenerator for DatabaseQueryGeneratorSqlite {}
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
**Motivation**
Improve the snapshot generation functionality by separating the query component from the snapshot creation script. The primary motivation behind this change is to enable the utilisation of the snapshot query independently, particularly for generating a "replica" view of the snapshot before it has been created in the documentation panel.

**Changes**
- Extracted the snapshot query generation logic into a separate function called generate_snapshot_query in the SnapshotGenerator trait.

- Updated the generate_snapshot_sql function to call generate_snapshot_query and use the returned query in the snapshot creation SQL statements.

- Adjusted the corresponding test cases to reflect the changes made to the snapshot generation logic, there are no changes to the actual query this is just minor formatting.