### PR TITLE
feat/connect snapshot query generator

### DIFF
--- a/rust/core/src/database_duckdb.rs
+++ b/rust/core/src/database_duckdb.rs
@@ -1,5 +1,6 @@
 use crate::databases::{
     base_for_seeds_create_table_specifying_text_type, DatabaseQueryGenerator, SnapshotGenerator,
+    Timestamp,
 };
 use chrono::{DateTime, Utc};
 use quary_proto::snapshot::snapshot_strategy::StrategyType;
@@ -23,17 +24,6 @@ impl DatabaseQueryGeneratorDuckDB {
             schema,
             override_now,
         }
-    }
-
-    fn get_now(&self) -> String {
-        let datetime = self
-            .override_now
-            .map(|time| -> DateTime<Utc> { time.into() })
-            .unwrap_or(SystemTime::now().into());
-        format!(
-            "CAST ('{}' AS TIMESTAMP WITH TIME ZONE)",
-            datetime.format("%Y-%m-%dT%H:%M:%SZ")
-        )
     }
 }
 
@@ -90,6 +80,17 @@ impl DatabaseQueryGenerator for DatabaseQueryGeneratorDuckDB {
     fn database_name_wrapper(&self, name: &str) -> String {
         name.into()
     }
+
+    fn get_current_timestamp(&self) -> Timestamp {
+        let datetime = self
+            .override_now
+            .map(|time| -> DateTime<Utc> { time.into() })
+            .unwrap_or(SystemTime::now().into());
+        format!(
+            "CAST ('{}' AS TIMESTAMP WITH TIME ZONE)",
+            datetime.format("%Y-%m-%dT%H:%M:%SZ")
+        )
+    }
 }
 
 impl SnapshotGenerator for DatabaseQueryGeneratorDuckDB {
@@ -106,7 +107,7 @@ impl SnapshotGenerator for DatabaseQueryGeneratorDuckDB {
             "table_exists is not necessary for DuckDB snapshots."
         );
 
-        let now = self.get_now();
+        let now = self.get_current_timestamp();
         let snapshot_query =
             self.generate_snapshot_query(templated_select, unique_key, strategy, now.as_str())?;
 
@@ -211,12 +212,12 @@ mod tests {
     }
 
     #[test]
-    fn test_get_now() {
+    fn test_get_current_timestamp() {
         let override_now = SystemTime::now();
         let database = DatabaseQueryGeneratorDuckDB::new(None, Some(override_now));
 
         // TODO Improve test
-        let result = database.get_now();
+        let result = database.get_current_timestamp();
         let expected_datetime: DateTime<Utc> = override_now.into();
         let expected_result = format!(
             "CAST ('{}' AS TIMESTAMP WITH TIME ZONE)",

--- a/rust/core/src/databases.rs
+++ b/rust/core/src/databases.rs
@@ -134,6 +134,11 @@ pub trait DatabaseQueryGenerator: SnapshotGenerator + Debug + Sync {
 
     /// database_name_wrapper returns a full path or name wrapped in quotes that work for the specific database
     fn database_name_wrapper(&self, name: &str) -> String;
+
+    /// get_current_timestamp returns the current timestamp (with TZ + hour in database format)
+    fn get_current_timestamp(&self) -> Timestamp {
+        panic!("get_current_timestamp not implemented for this database")
+    }
 }
 
 pub trait SnapshotGenerator {
@@ -301,6 +306,9 @@ impl QueryResult {
         Ok(quary_proto::QueryResult { columns: values })
     }
 }
+
+// Timestamp is a type alias for a String that represents a formatted database timestamp.
+pub type Timestamp = String;
 
 #[cfg(test)]
 mod tests {

--- a/rust/core/src/project.rs
+++ b/rust/core/src/project.rs
@@ -1569,7 +1569,7 @@ async fn render_model_select_statement(
 }
 
 async fn render_snapshot_select_statement(
-    database: &impl DatabaseQueryGenerator,
+    database: &dyn DatabaseQueryGenerator,
     fs: &impl FileSystem,
     snapshot: &Snapshot,
     project: &Project,
@@ -1611,7 +1611,12 @@ async fn render_snapshot_select_statement(
         .strategy_type
         .ok_or("missing snapshot strategy type")?;
 
-    database.generate_snapshot_query(&replaced, &snapshot.unique_key, &snapshot_strategy_type)
+    database.generate_snapshot_query(
+        &replaced,
+        &snapshot.unique_key,
+        &snapshot_strategy_type,
+        &database.get_current_timestamp(),
+    )
 }
 
 pub fn replace_variable_templates_with_variable_defined_in_config(

--- a/rust/quary-databases/src/databases_postgres.rs
+++ b/rust/quary-databases/src/databases_postgres.rs
@@ -253,43 +253,24 @@ impl DatabaseConnection for Postgres {
         fn convert_value_to_string(row: &PgRow, i: usize) -> Result<String, Error> {
             let type_name = row.column(i).type_info().name();
             let value: Option<String> = match type_name {
-                "INT4" => {
-                    row.try_get::<Option<i32>, _>(i)?.map(|v| v.to_string())
-                }
-                "INT8" => {
-                    row.try_get::<Option<i64>, _>(i)?.map(|v| v.to_string())
-                }
-                "FLOAT8" => {
-                    row.try_get::<Option<f64>, _>(i)?.map(|v| v.to_string())
-                }
-                "BOOL" => {
-                    row.try_get::<Option<bool>, _>(i)?.map(|v| v.to_string())
-                }
-                "TIMESTAMP" => {
-                    row
-                        .try_get::<Option<chrono::NaiveDateTime>, _>(i)?
-                        .map(|v| v.format("%Y-%m-%dT%H:%M:%S").to_string())
-                }
-                "TIMESTAMPTZ" => {
-                    row.try_get::<Option<DateTime<Utc>>, _>(i)?
-                        .map(|v| v.to_rfc3339())
-                }
-                "TEXT" => {
-                    row.try_get::<Option<String>, _>(i)?
-                }
-                "VARCHAR" => {
-                   row.try_get::<Option<String>, _>(i)?
-                }
-                "DATE" => {
-                    row
-                        .try_get::<Option<chrono::NaiveDate>, _>(i)?
-                        .map(|v| v.format("%Y-%m-%d").to_string())
-                }
-                "NUMERIC" => {
-                    row
-                        .try_get::<Option<BigDecimal>, _>(i)?
-                        .map(|v| v.to_string())
-                }
+                "INT4" => row.try_get::<Option<i32>, _>(i)?.map(|v| v.to_string()),
+                "INT8" => row.try_get::<Option<i64>, _>(i)?.map(|v| v.to_string()),
+                "FLOAT8" => row.try_get::<Option<f64>, _>(i)?.map(|v| v.to_string()),
+                "BOOL" => row.try_get::<Option<bool>, _>(i)?.map(|v| v.to_string()),
+                "TIMESTAMP" => row
+                    .try_get::<Option<chrono::NaiveDateTime>, _>(i)?
+                    .map(|v| v.format("%Y-%m-%dT%H:%M:%S").to_string()),
+                "TIMESTAMPTZ" => row
+                    .try_get::<Option<DateTime<Utc>>, _>(i)?
+                    .map(|v| v.to_rfc3339()),
+                "TEXT" => row.try_get::<Option<String>, _>(i)?,
+                "VARCHAR" => row.try_get::<Option<String>, _>(i)?,
+                "DATE" => row
+                    .try_get::<Option<chrono::NaiveDate>, _>(i)?
+                    .map(|v| v.format("%Y-%m-%d").to_string()),
+                "NUMERIC" => row
+                    .try_get::<Option<BigDecimal>, _>(i)?
+                    .map(|v| v.to_string()),
                 _ => Some(format!("Unsupported type: {}", type_name)),
             };
             match value {

--- a/rust/quary-databases/src/databases_sqlite.rs
+++ b/rust/quary-databases/src/databases_sqlite.rs
@@ -323,10 +323,15 @@ mod tests {
             .await
             .unwrap();
 
-        let sqls =
-            project_and_fs_to_sql_for_views(&project, &file_system, &*query_generator, false, false)
-                .await
-                .unwrap();
+        let sqls = project_and_fs_to_sql_for_views(
+            &project,
+            &file_system,
+            &*query_generator,
+            false,
+            false,
+        )
+        .await
+        .unwrap();
 
         assert!(!sqls.is_empty());
 
@@ -380,10 +385,15 @@ mod tests {
             .await
             .unwrap();
 
-        let sqls =
-            project_and_fs_to_sql_for_views(&project, &file_system, &*query_generator, false, false)
-                .await
-                .unwrap();
+        let sqls = project_and_fs_to_sql_for_views(
+            &project,
+            &file_system,
+            &*query_generator,
+            false,
+            false,
+        )
+        .await
+        .unwrap();
 
         assert!(!sqls.is_empty());
 
@@ -458,10 +468,15 @@ mod tests {
             .await
             .unwrap();
 
-        let sqls =
-            project_and_fs_to_sql_for_views(&project, &file_system, &*query_generator, false, false)
-                .await
-                .unwrap();
+        let sqls = project_and_fs_to_sql_for_views(
+            &project,
+            &file_system,
+            &*query_generator,
+            false,
+            false,
+        )
+        .await
+        .unwrap();
 
         assert!(!sqls.is_empty());
 
@@ -592,10 +607,15 @@ sources:
         );
 
         let query_generator = sqlite.query_generator();
-        let sqls =
-            project_and_fs_to_sql_for_views(&project, &file_system, &*query_generator, false, false)
-                .await
-                .unwrap();
+        let sqls = project_and_fs_to_sql_for_views(
+            &project,
+            &file_system,
+            &*query_generator,
+            false,
+            false,
+        )
+        .await
+        .unwrap();
 
         // assert
         // assert can find new model


### PR DESCRIPTION
- Renamed get_now() to get_current_timestamp() in DatabaseQueryGenerator trait and its implementations
- Moved get_current_timestamp() from individual database implementations to the DatabaseQueryGenerator trait
   - The reason for doing this is that generate_snapshot_query expects 'now' as an input to the function. This makes sense as we don't want to generate multiple times that may differ even by a few milliseconds. This is why I have needed to add get_current_timestamp to the trait so that we can call generate_snapshot_query independently 
- Implemented render_snapshot_select_statement() in project.rs to support snapshot select functionality
