### PR TITLE
chore: refactor database query generator usage

### DIFF
--- a/rust/cli/src/rpc_functions.rs
+++ b/rust/cli/src/rpc_functions.rs
@@ -99,7 +99,7 @@ async fn list_sources(
     _: ListSourcesRequest,
     database: Box<dyn DatabaseConnection>,
 ) -> Result<ListSourcesResponse, String> {
-    let sources = generate_sources(database.as_ref())
+    let sources = generate_sources(&*database)
         .await
         .map_err(|e| format!("Failed to list sources: {}", e))?;
     Ok(ListSourcesResponse { sources })

--- a/rust/core/src/automatic_branching.rs
+++ b/rust/core/src/automatic_branching.rs
@@ -91,7 +91,7 @@ pub fn derive_model_hash(
         }
         hasher.finalize()
     };
-    Ok(HEXLOWER.encode(hash_of_hashes.as_ref()))
+    Ok(HEXLOWER.encode(&*hash_of_hashes))
 }
 
 fn hash_source(source: &Source) -> String {
@@ -139,7 +139,7 @@ pub async fn derive_sha256_file_contents(
 /// and seed inside of the project that is passed in. The returned type is a map from the model
 /// to a tuple of the model hash and sql statements required to create the view.
 pub fn derive_hash_views<'a>(
-    database: &impl DatabaseQueryGenerator,
+    database: &dyn DatabaseQueryGenerator,
     project: &'a Project,
     project_graph: &'_ ProjectGraph,
 ) -> Result<BTreeMap<ModelName<'a>, (String, Vec<String>)>, String> {
@@ -206,7 +206,7 @@ pub fn cache_view_name_to_table_name_and_hash(
 
 /// is_cache_full_path returns true if the full path is a cache view name.
 pub fn is_cache_full_path(
-    database: &impl DatabaseQueryGenerator,
+    database: &dyn DatabaseQueryGenerator,
     full_path: &str,
 ) -> Result<bool, String> {
     let view_name = database.return_name_from_full_path(full_path)?;

--- a/rust/core/src/databases.rs
+++ b/rust/core/src/databases.rs
@@ -136,85 +136,6 @@ pub trait DatabaseQueryGenerator: SnapshotGenerator + Debug + Sync {
     fn database_name_wrapper(&self, name: &str) -> String;
 }
 
-impl DatabaseQueryGenerator for Box<dyn DatabaseQueryGenerator> {
-    fn validate_materialization_type(
-        &self,
-        materialization_type: &Option<String>,
-    ) -> Result<(), String> {
-        self.as_ref()
-            .validate_materialization_type(materialization_type)
-    }
-
-    fn models_drop_query(
-        &self,
-        view_name: &str,
-        materialization_type: &Option<String>,
-    ) -> Result<String, String> {
-        self.as_ref()
-            .models_drop_query(view_name, materialization_type)
-    }
-
-    fn models_create_query(
-        &self,
-        view_name: &str,
-        original_select_statement: &str,
-        materialization_type: &Option<String>,
-    ) -> Result<String, String> {
-        self.as_ref().models_create_query(
-            view_name,
-            original_select_statement,
-            materialization_type,
-        )
-    }
-
-    fn seeds_drop_table_query(&self, table_name: &str) -> String {
-        self.as_ref().seeds_drop_table_query(table_name)
-    }
-
-    fn seeds_create_table_query(&self, table_name: &str, columns: &[String]) -> String {
-        self.as_ref().seeds_create_table_query(table_name, columns)
-    }
-
-    fn seeds_insert_into_table_query(
-        &self,
-        table_name: &str,
-        columns: &[String],
-        values: &[Vec<String>],
-    ) -> String {
-        self.as_ref()
-            .seeds_insert_into_table_query(table_name, columns, values)
-    }
-
-    fn escape_seed_value(&self, seed_value: &str) -> String {
-        self.as_ref().escape_seed_value(seed_value)
-    }
-
-    fn return_full_path_requirement(&self, table_name: &str) -> String {
-        self.as_ref().return_full_path_requirement(table_name)
-    }
-
-    fn return_name_from_full_path<'a>(&self, full_path: &'a str) -> Result<&'a str, String> {
-        self.as_ref().return_name_from_full_path(full_path)
-    }
-
-    fn automatic_cache_sql_create_statement(
-        &self,
-        model: &str,
-        model_cache_name: &str,
-    ) -> Vec<String> {
-        self.as_ref()
-            .automatic_cache_sql_create_statement(model, model_cache_name)
-    }
-
-    fn get_dialect(&self) -> &Dialect {
-        self.as_ref().get_dialect()
-    }
-
-    fn database_name_wrapper(&self, name: &str) -> String {
-        self.as_ref().database_name_wrapper(name)
-    }
-}
-
 pub trait SnapshotGenerator {
     /// GenerateSnapshotSQL generates the SQL statements to create a snapshot of a table.
     ///
@@ -262,36 +183,6 @@ pub trait SnapshotGenerator {
         _now: &str,
     ) -> Result<String, String> {
         Err("Database does not support snapshots".to_string())
-    }
-}
-
-impl SnapshotGenerator for Box<dyn DatabaseQueryGenerator> {
-    fn generate_snapshot_sql(
-        &self,
-        path: &str,
-        templated_select: &str,
-        unique_key: &str,
-        strategy: &StrategyType,
-        table_exists: Option<bool>,
-    ) -> Result<Vec<String>, String> {
-        self.as_ref().generate_snapshot_sql(
-            path,
-            templated_select,
-            unique_key,
-            strategy,
-            table_exists,
-        )
-    }
-
-    fn generate_snapshot_query(
-        &self,
-        templated_select: &str,
-        unique_key: &str,
-        strategy: &StrategyType,
-        now: &str,
-    ) -> Result<String, String> {
-        self.as_ref()
-            .generate_snapshot_query(templated_select, unique_key, strategy, now)
     }
 }
 

--- a/rust/core/src/models.rs
+++ b/rust/core/src/models.rs
@@ -25,7 +25,7 @@ pub fn validate_model_name(name: &str) -> Result<(), String> {
 /// parse_model_schemas_to_views takes in a reader and reads it to a View file
 /// name_replacing_strategy takes in the reference name and replaces it with whatever strategy is necessary.
 pub async fn parse_model_schemas_to_views<F>(
-    database: &impl DatabaseQueryGenerator,
+    database: &dyn DatabaseQueryGenerator,
     file_reader: Box<dyn AsyncRead + Send + Unpin>,
     view_name: &str,
     materialization: &Option<String>,
@@ -76,7 +76,7 @@ pub async fn read_normalise_model(
 }
 
 fn return_sql_model_template(
-    database: &impl DatabaseQueryGenerator,
+    database: &dyn DatabaseQueryGenerator,
     name: &str,
     materialization: &Option<String>,
     select_statement: &str,

--- a/rust/core/src/project.rs
+++ b/rust/core/src/project.rs
@@ -160,7 +160,7 @@ pub fn return_tests_for_a_particular_model<'a>(
 /// ParseProject parses a whole project into a project object.
 pub async fn parse_project(
     filesystem: &impl FileSystem,
-    database: &impl DatabaseQueryGenerator,
+    database: &dyn DatabaseQueryGenerator,
     project_root: &str,
 ) -> Result<Project, String> {
     let seeds = parse_seeds(filesystem, project_root)
@@ -275,7 +275,7 @@ pub async fn parse_project(
 
 async fn parse_tests(
     filesystem: &impl FileSystem,
-    database: &impl DatabaseQueryGenerator,
+    database: &dyn DatabaseQueryGenerator,
     project_root: &str,
     path_map: &PathMap,
     project_files: &HashMap<String, ProjectFile>,
@@ -373,7 +373,7 @@ async fn parse_sql_tests(
 }
 
 pub fn create_path_map(
-    database: &impl DatabaseQueryGenerator,
+    database: &dyn DatabaseQueryGenerator,
     models: Vec<&Model>,
     sources: Vec<&Source>,
     snapshots: Vec<&Snapshot>,
@@ -773,7 +773,7 @@ async fn parse_seeds<'a>(
 pub async fn parse_project_files(
     filesystem: &impl FileSystem,
     project_root: &str,
-    database: &impl DatabaseQueryGenerator, // Map of full path to project file and project file
+    database: &dyn DatabaseQueryGenerator, // Map of full path to project file and project file
 ) -> Result<HashMap<String, ProjectFile>, String> {
     let paths = get_path_bufs(
         filesystem,
@@ -841,7 +841,7 @@ fn parse_sources(
 type PathMap = HashMap<String, String>;
 
 fn parse_column_tests(
-    database: &impl DatabaseQueryGenerator,
+    database: &dyn DatabaseQueryGenerator,
     project_files: &HashMap<String, ProjectFile>,
     path_map: &PathMap,
 ) -> Result<HashMap<String, Test>, String> {
@@ -884,7 +884,7 @@ fn parse_column_tests(
 
 /// parse_model_tests_in_project_files returns the tests for both the source and model tests
 fn parse_model_tests_in_project_files(
-    database: &impl DatabaseQueryGenerator,
+    database: &dyn DatabaseQueryGenerator,
     project_files: &HashMap<String, ProjectFile>,
 ) -> Result<HashMap<String, Test>, String> {
     let mut m = HashMap::<String, Test>::new();
@@ -1104,7 +1104,7 @@ fn parse_column_tests_for_model_or_source(
 /// Returns a tuple of the sql statement and the (nodes, edges) that were used to create the sql
 /// statement.
 pub async fn project_and_fs_to_query_sql(
-    database: &impl DatabaseQueryGenerator,
+    database: &dyn DatabaseQueryGenerator,
     project: &Project,
     file_system: &impl FileSystem,
     model_name: &str,
@@ -1195,7 +1195,7 @@ pub async fn project_and_fs_to_query_sql(
 pub async fn project_and_fs_to_sql_for_views(
     project: &Project,
     file_system: &impl FileSystem,
-    database: &impl DatabaseQueryGenerator,
+    database: &dyn DatabaseQueryGenerator,
     only_models: bool,
     do_not_include_seeds_data: bool,
 ) -> Result<Vec<(String, Vec<String>)>, String> {
@@ -1301,7 +1301,7 @@ pub async fn project_and_fs_to_sql_for_views(
 pub async fn project_and_fs_to_sql_for_snapshots(
     project: &Project,
     file_system: &impl FileSystem,
-    database: &impl DatabaseQueryGenerator,
+    database: &dyn DatabaseQueryGenerator,
     database_connection: &dyn DatabaseConnection,
 ) -> Result<Vec<(String, Vec<String>)>, String> {
     let snapshots_out = project.snapshots.values().map(|snapshot| async move {
@@ -1333,7 +1333,7 @@ pub async fn project_and_fs_to_sql_for_snapshots(
 async fn generate_snapshot_sql(
     connection_config: &ConnectionConfig,
     project: &Project,
-    database: &impl DatabaseQueryGenerator,
+    database: &dyn DatabaseQueryGenerator,
     file_system: &impl FileSystem,
     snapshot: &Snapshot,
     database_connection: &dyn DatabaseConnection,
@@ -1394,7 +1394,7 @@ async fn generate_snapshot_sql(
 ///
 /// array of models is in the shape of [][2]string where the first element is the name of the model and the second element is the sql
 async fn convert_to_select_statement(
-    database: &impl DatabaseQueryGenerator,
+    database: &dyn DatabaseQueryGenerator,
     file_system: &impl FileSystem,
     values: &[NodeWithName],
     project: &Project,
@@ -1455,7 +1455,7 @@ async fn convert_to_select_statement(
 }
 
 async fn render_seed_select_statement(
-    database: &impl DatabaseQueryGenerator,
+    database: &dyn DatabaseQueryGenerator,
     fs: &impl FileSystem,
     seed: &Seed,
 ) -> Result<String, String> {
@@ -1493,7 +1493,7 @@ async fn render_seed_select_statement(
 }
 
 fn render_seed_select_statement_string(
-    database: &impl DatabaseQueryGenerator,
+    database: &dyn DatabaseQueryGenerator,
     headers: Vec<String>,
     values: Vec<Vec<String>>,
 ) -> String {
@@ -1531,7 +1531,7 @@ fn render_override_select_statement(override_target: &str) -> String {
 }
 
 async fn render_model_select_statement(
-    database: &impl DatabaseQueryGenerator,
+    database: &dyn DatabaseQueryGenerator,
     fs: &impl FileSystem,
     model: &Model,
     project: &Project,
@@ -1605,7 +1605,7 @@ pub fn replace_variable_templates_with_variable_defined_in_config(
 
 fn replace_reference_string_found_with_database<'a>(
     sources: &'a HashMap<String, Source>,
-    database: &'a &impl DatabaseQueryGenerator,
+    database: &'a &dyn DatabaseQueryGenerator,
 ) -> Box<dyn Fn(&regex::Captures) -> String + 'a> {
     #[allow(clippy::indexing_slicing)]
     Box::new(move |caps: &regex::Captures| {
@@ -1621,7 +1621,7 @@ fn replace_reference_string_found_with_database<'a>(
 
 pub fn replace_reference_string_found<'a>(
     overrides: &'a HashMap<String, String>,
-    database: &'a &impl DatabaseQueryGenerator,
+    database: &'a &dyn DatabaseQueryGenerator,
 ) -> Box<dyn Fn(&regex::Captures) -> String + 'a> {
     #[allow(clippy::indexing_slicing)]
     Box::new(move |caps: &regex::Captures| {

--- a/rust/core/src/project_tests.rs
+++ b/rust/core/src/project_tests.rs
@@ -27,7 +27,7 @@ use std::pin::Pin;
 ///
 /// filter_by_model if set to Some(&str) will filter the tests to only return tests related to the model.
 pub async fn return_tests_sql(
-    database: &(impl DatabaseQueryGenerator + Sync),
+    database: &dyn DatabaseQueryGenerator,
     project: &Project,
     fs: &impl FileSystem,
     whether_to_make_test_include_models_to_source: bool,

--- a/rust/core/src/rpc_proto_defined_functions.rs
+++ b/rust/core/src/rpc_proto_defined_functions.rs
@@ -198,7 +198,7 @@ pub async fn name_to_raw_model_map_internal(
 }
 
 pub async fn render_schema_internal(
-    database: &impl DatabaseQueryGenerator,
+    database: &dyn DatabaseQueryGenerator,
     project: Option<Project>,
     file_system: Option<quary_proto::FileSystem>,
 ) -> Result<String, String> {
@@ -223,7 +223,7 @@ pub async fn render_schema_internal(
 pub async fn return_full_sql_for_new_model(
     file_system: quary_proto::FileSystem,
     project_root: &str,
-    database: &impl DatabaseQueryGenerator,
+    database: &dyn DatabaseQueryGenerator,
     model_sql: &str,
     model_name: &str,
 ) -> Result<(Vec<Edge>, BTreeSet<String>), String> {

--- a/rust/core/src/seeds.rs
+++ b/rust/core/src/seeds.rs
@@ -5,7 +5,7 @@ use std::collections::HashSet;
 use std::error::Error;
 
 pub async fn parse_table_schema_seeds(
-    database: &impl DatabaseQueryGenerator,
+    database: &dyn DatabaseQueryGenerator,
     table_name: &str,
     reader: Box<dyn AsyncRead + Send + Unpin>,
     do_not_include_data: bool,

--- a/rust/core/src/test_runner.rs
+++ b/rust/core/src/test_runner.rs
@@ -62,7 +62,7 @@ pub enum RunTestError {
 /// quickly and not have to wait for an number of results, greater than the limit to be returned. This is useful for
 /// CI environments where we want to run tests quickly and not wait for a large number of results to be returned.
 pub async fn run_tests_internal(
-    database: &impl DatabaseQueryGenerator,
+    database: &dyn DatabaseQueryGenerator,
     file_system: &impl FileSystem,
     project: &Project,
     project_root: &str,
@@ -401,7 +401,7 @@ pub async fn run_tests_internal(
 /// quickly and not have to wait for an number of results, greater than the limit to be returned. This is useful for
 /// CI environments where we want to run tests quickly and not wait for a large number of results to be returned.
 pub async fn run_model_tests_internal(
-    database: &impl DatabaseQueryGenerator,
+    database: &dyn DatabaseQueryGenerator,
     file_system: &impl FileSystem,
     project: &Project,
     run_statement: RunStatementFunc,

--- a/rust/quary-databases/src/databases_duckdb.rs
+++ b/rust/quary-databases/src/databases_duckdb.rs
@@ -567,12 +567,12 @@ HAVING COUNT(*) > 1;",
             .collect(),
         };
 
-        let project = parse_project(&file_system, &database.query_generator(), "")
+        let project = parse_project(&file_system, &*database.query_generator(), "")
             .await
             .unwrap();
 
         let tests = return_tests_sql(
-            &database.query_generator(),
+            &*database.query_generator(),
             &project,
             &file_system,
             true,
@@ -680,12 +680,12 @@ HAVING COUNT(*) > 1;",
             .collect(),
         };
 
-        let project = parse_project(&file_system, &database.query_generator(), "")
+        let project = parse_project(&file_system, &*database.query_generator(), "")
             .await
             .unwrap();
 
         let tests = return_tests_sql(
-            &database.query_generator(),
+            &*database.query_generator(),
             &project,
             &file_system,
             true,
@@ -749,13 +749,13 @@ sources:
             .collect(),
         };
 
-        let project = parse_project(&file_system, &database.query_generator(), "")
+        let project = parse_project(&file_system, &*database.query_generator(), "")
             .await
             .unwrap();
         let sqls = project_and_fs_to_sql_for_views(
             &project,
             &file_system,
-            &database.query_generator(),
+            &*database.query_generator(),
             false,
             false,
         )
@@ -768,7 +768,7 @@ sources:
         }
 
         let tests = return_tests_sql(
-            &database.query_generator(),
+            &*database.query_generator(),
             &project,
             &file_system,
             false,
@@ -852,7 +852,7 @@ snapshots:
             &project,
             &file_system,
             &DatabaseQueryGeneratorDuckDB::new(target_schema.clone(), None),
-            database.as_ref(),
+            &*database,
         )
         .await
         .unwrap();
@@ -957,7 +957,7 @@ snapshots:
             .unwrap();
 
         let snapshots_sql =
-            project_and_fs_to_sql_for_snapshots(&project, &file_system, &db_generator, database.as_ref())
+            project_and_fs_to_sql_for_snapshots(&project, &file_system, &db_generator, &*database)
                 .await
                 .unwrap();
         for (_, sql) in snapshots_sql {
@@ -1028,7 +1028,7 @@ snapshots:
             &project,
             &file_system,
             &db_generator_updated,
-            database.as_ref(),
+            &*database,
         )
         .await
         .unwrap();
@@ -1185,7 +1185,7 @@ snapshots:
             .unwrap();
 
         let snapshots_sql =
-            project_and_fs_to_sql_for_snapshots(&project, &file_system, &db_generator, database.as_ref())
+            project_and_fs_to_sql_for_snapshots(&project, &file_system, &db_generator, &*database)
                 .await
                 .unwrap();
         for (_, sql) in snapshots_sql {
@@ -1257,7 +1257,7 @@ snapshots:
             &project,
             &file_system,
             &db_generator_updated,
-            database.as_ref(),
+            &*database,
         )
         .await
         .unwrap();

--- a/rust/quary-databases/src/databases_postgres.rs
+++ b/rust/quary-databases/src/databases_postgres.rs
@@ -384,13 +384,13 @@ mod tests {
             .collect(),
         };
 
-        let project = parse_project(&filesystem, &quary_postgres.query_generator(), "")
+        let project = parse_project(&filesystem, &*quary_postgres.query_generator(), "")
             .await
             .unwrap();
         let sqls = project_and_fs_to_sql_for_views(
             &project,
             &filesystem,
-            &quary_postgres.query_generator(),
+            &*quary_postgres.query_generator(),
             false,
             false,
         )
@@ -705,12 +705,12 @@ models:
             .collect(),
         };
 
-        let project = parse_project(&file_system, &database.query_generator(), "")
+        let project = parse_project(&file_system, &*database.query_generator(), "")
             .await
             .unwrap();
 
         let tests = return_tests_sql(
-            &database.query_generator(),
+            &*database.query_generator(),
             &project,
             &file_system,
             true,
@@ -830,14 +830,14 @@ models:
             .collect(),
         };
 
-        let project = parse_project(&file_system, &database.query_generator(), "")
+        let project = parse_project(&file_system, &*database.query_generator(), "")
             .await
             .unwrap();
 
         let sqls = project_and_fs_to_sql_for_views(
             &project,
             &file_system,
-            &database.query_generator(),
+            &*database.query_generator(),
             false,
             false,
         )
@@ -856,7 +856,7 @@ models:
         }
 
         let tests = return_tests_sql(
-            &database.query_generator(),
+            &*database.query_generator(),
             &project,
             &file_system,
             false,
@@ -1105,7 +1105,7 @@ snapshots:
             &project,
             &file_system,
             &DatabaseQueryGeneratorPostgres::new(schema.to_string(), None),
-            database.as_ref(),
+            &*database,
         )
         .await
         .unwrap();
@@ -1231,7 +1231,7 @@ snapshots:
             .unwrap();
 
         let snapshots_sql =
-            project_and_fs_to_sql_for_snapshots(&project, &file_system, &db_generator, database.as_ref())
+            project_and_fs_to_sql_for_snapshots(&project, &file_system, &db_generator, &*database)
                 .await
                 .unwrap();
         for (_, sql) in snapshots_sql {
@@ -1306,7 +1306,7 @@ snapshots:
             &project,
             &file_system,
             &db_generator_updated,
-            database.as_ref(),
+            &*database,
         )
         .await
         .unwrap();

--- a/rust/quary-databases/src/databases_redshift.rs
+++ b/rust/quary-databases/src/databases_redshift.rs
@@ -369,12 +369,12 @@ mod tests {
             .collect(),
         };
 
-        let project = parse_project(&file_system, &database.query_generator(), "")
+        let project = parse_project(&file_system, &*database.query_generator(), "")
             .await
             .unwrap();
 
         let tests = return_tests_sql(
-            &database.query_generator(),
+            &*database.query_generator(),
             &project,
             &file_system,
             true,
@@ -484,14 +484,14 @@ mod tests {
             .collect(),
         };
 
-        let project = parse_project(&file_system, &database.query_generator(), "")
+        let project = parse_project(&file_system, &*database.query_generator(), "")
             .await
             .unwrap();
 
         let sqls = project_and_fs_to_sql_for_views(
             &project,
             &file_system,
-            &database.query_generator(),
+            &*database.query_generator(),
             false,
             false,
         )
@@ -510,7 +510,7 @@ mod tests {
         }
 
         let tests = return_tests_sql(
-            &database.query_generator(),
+            &*database.query_generator(),
             &project,
             &file_system,
             false,
@@ -718,7 +718,7 @@ mod tests {
             .unwrap();
 
         let snapshots_sql =
-            project_and_fs_to_sql_for_snapshots(&project, &file_system, &db_generator, database.as_ref())
+            project_and_fs_to_sql_for_snapshots(&project, &file_system, &db_generator, &*database)
                 .await
                 .unwrap();
         for (_, sql) in snapshots_sql {
@@ -794,7 +794,7 @@ mod tests {
             &project,
             &file_system,
             &db_generator_updated,
-            database.as_ref(),
+            &*database,
         )
         .await
         .unwrap();

--- a/rust/quary-databases/src/databases_sqlite.rs
+++ b/rust/quary-databases/src/databases_sqlite.rs
@@ -319,12 +319,12 @@ mod tests {
 
         let file_system = Asset {};
         let query_generator = sqlite.query_generator();
-        let project = parse_project(&file_system, &query_generator, "")
+        let project = parse_project(&file_system, &*query_generator, "")
             .await
             .unwrap();
 
         let sqls =
-            project_and_fs_to_sql_for_views(&project, &file_system, &query_generator, false, false)
+            project_and_fs_to_sql_for_views(&project, &file_system, &*query_generator, false, false)
                 .await
                 .unwrap();
 
@@ -351,11 +351,11 @@ mod tests {
 
         let file_system = Asset {};
         let query_generator = sqlite.query_generator();
-        let project = parse_project(&file_system, &query_generator, "")
+        let project = parse_project(&file_system, &*query_generator, "")
             .await
             .unwrap();
 
-        let tests = return_tests_sql(&database, &project, &file_system, true, None, None)
+        let tests = return_tests_sql(&*database, &project, &file_system, true, None, None)
             .await
             .unwrap();
         let tests = tests.iter().collect::<Vec<_>>();
@@ -376,12 +376,12 @@ mod tests {
 
         let file_system = Asset {};
         let query_generator = sqlite.query_generator();
-        let project = parse_project(&file_system, &query_generator, "")
+        let project = parse_project(&file_system, &*query_generator, "")
             .await
             .unwrap();
 
         let sqls =
-            project_and_fs_to_sql_for_views(&project, &file_system, &query_generator, false, false)
+            project_and_fs_to_sql_for_views(&project, &file_system, &*query_generator, false, false)
                 .await
                 .unwrap();
 
@@ -415,7 +415,7 @@ mod tests {
         });
 
         let results = run_tests_internal(
-            &query_generator,
+            &*query_generator,
             &file_system,
             &project,
             "",
@@ -454,12 +454,12 @@ mod tests {
 
         let file_system = Asset {};
         let query_generator = sqlite.query_generator();
-        let project = parse_project(&file_system, &query_generator, "")
+        let project = parse_project(&file_system, &*query_generator, "")
             .await
             .unwrap();
 
         let sqls =
-            project_and_fs_to_sql_for_views(&project, &file_system, &query_generator, false, false)
+            project_and_fs_to_sql_for_views(&project, &file_system, &*query_generator, false, false)
                 .await
                 .unwrap();
 
@@ -493,7 +493,7 @@ mod tests {
         });
 
         let results = run_tests_internal(
-            &query_generator,
+            &*query_generator,
             &file_system,
             &project,
             "",
@@ -568,7 +568,7 @@ sources:
             },
         );
 
-        let project = parse_project(&file_system, &sqlite.query_generator(), "")
+        let project = parse_project(&file_system, &*sqlite.query_generator(), "")
             .await
             .unwrap();
 
@@ -593,7 +593,7 @@ sources:
 
         let query_generator = sqlite.query_generator();
         let sqls =
-            project_and_fs_to_sql_for_views(&project, &file_system, &query_generator, false, false)
+            project_and_fs_to_sql_for_views(&project, &file_system, &*query_generator, false, false)
                 .await
                 .unwrap();
 
@@ -664,7 +664,7 @@ sources:
             },
         );
 
-        let project = parse_project(&file_system, &sqlite.query_generator(), "")
+        let project = parse_project(&file_system, &*sqlite.query_generator(), "")
             .await
             .unwrap();
 
@@ -678,7 +678,7 @@ sources:
         // asser that can get and apply each successfully
         for model_name in model_names {
             let (sql, _) = project_and_fs_to_query_sql(
-                &sqlite.query_generator(),
+                &*sqlite.query_generator(),
                 &project,
                 &file_system,
                 model_name,
@@ -731,13 +731,13 @@ models:
             },
         );
 
-        let project = parse_project(&file_system, &sqlite.query_generator(), "")
+        let project = parse_project(&file_system, &*sqlite.query_generator(), "")
             .await
             .unwrap();
 
         // asser that can get and apply each successfully
         let (sql, _) = project_and_fs_to_query_sql(
-            &sqlite.query_generator(),
+            &*sqlite.query_generator(),
             &project,
             &file_system,
             new_model,


### PR DESCRIPTION
### Refactor DatabaseQueryGenerator usage and remove duplicate trait implementations

Goal: Improve the usage of the DatabaseQueryGenerator trait and its associated types throughout the codebase. The main goals of these changes are to:

- Remove duplicate trait implementations for Box<dyn DatabaseQueryGenerator> to simplify the code and avoid confusion.
- Modify functions that accept DatabaseQueryGenerator instances to take references to dyn trait objects directly, instead of using impl with additional trait bounds.
- Update the code that uses the query_generator method to work with boxed trait objects and references to dyn trait objects.

The key changes made in this pull request include:

- Removed the duplicate trait implementations for Box<dyn DatabaseQueryGenerator> in the DatabaseQueryGenerator and SnapshotGenerator traits.

- Modified functions like project_and_fs_to_query_sql and return_tests_sql to accept &dyn DatabaseQueryGenerator instead of &impl DatabaseQueryGenerator.

- Updated the code that calls the query_generator method to use &* or as_ref() to get a reference to the underlying dyn trait object.

This provides a more consistent  approach to working with DatabaseQueryGenerator instances. By using boxed trait objects and references to dyn trait objects, we can easily pass around and use different implementations of the trait without the need for static dispatch or additional trait bounds.

The refactoring also improves the maintainability and readability of the codebase by removing duplicate code and providing a cleaner way to work with the DatabaseQueryGenerator trait.