### PR TITLE
conditional materialized view refresh and create-replace for the view

### DIFF
--- a/rust/core/src/database_postgres.rs
+++ b/rust/core/src/database_postgres.rs
@@ -47,7 +47,11 @@ impl DatabaseQueryGenerator for DatabaseQueryGeneratorPostgres {
             None => Ok(format!("DROP VIEW IF EXISTS {}", object_name).to_string()),
             Some(materialization_type) if materialization_type == MATERIALIZATION_TYPE_VIEW => {
                 println!("don't drop view");
-                Ok(format!("select 1 from pg_matviews where matviewname = '{}'", object_name).to_string())
+                Ok(format!(
+                    "select 1 from pg_matviews where matviewname = '{}'",
+                    object_name
+                )
+                .to_string())
             }
             Some(materialization_type) if materialization_type == MATERIALIZATION_TYPE_TABLE => {
                 Ok(format!("DROP TABLE IF EXISTS {}", object_name).to_string())
@@ -56,7 +60,11 @@ impl DatabaseQueryGenerator for DatabaseQueryGeneratorPostgres {
                 if materialization_type == MATERIALIZATION_TYPE_MATERIALIZED_VIEW =>
             {
                 println!("don't drop materialized view");
-                Ok(format!("select 1 from pg_matviews where matviewname = '{}'", object_name).to_string())
+                Ok(format!(
+                    "select 1 from pg_matviews where matviewname = '{}'",
+                    object_name
+                )
+                .to_string())
             }
             Some(materialization_type) => Err(format!(
                 "Unsupported materialization type: {}",
@@ -97,7 +105,10 @@ impl DatabaseQueryGenerator for DatabaseQueryGeneratorPostgres {
                     EXECUTE format('CREATE MATERIALIZED VIEW {} AS {}');
                  END IF;
                  END $$;",
-                object_name.split('.').last().unwrap_or(""), object_name, object_name, original_select_statement
+                object_name.split('.').last().unwrap_or(""),
+                object_name,
+                object_name,
+                original_select_statement
             )),
             _ => Err("Unsupported materialization type".to_string()),
         }


### PR DESCRIPTION
hi I've started testing  `quary` in the production and hitting dependencies errors: If I follow the logic of `DROP/CREATE` view  I can't do it without `CASCADE` deleting all dependencies. The same with `materialized views`.

I suggest that for the view and materialized view there would be no `DROP` command and then changed creation commands:
- `view` : `CREATE OR REPLACE VIEW ...` 
- `materialized view`: checking if the view exists first and based on that either `REFRESH MATERIALIZED VIEW ..` or `CREATE MATERIALIZED VIEW ..`. In case of `REFRESH` there is no issue with dependent views.

thank you