### PR TITLE
Fix install script to use unzip for zip files

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -6,8 +6,8 @@ readonly GREEN="$(tput setaf 2 2>/dev/null || echo '')"
 readonly CYAN="$(tput setaf 6 2>/dev/null || echo '')"
 readonly NO_COLOR="$(tput sgr0 2>/dev/null || echo '')"
 
-if ! command -v tar >/dev/null 2>&1; then
-    echo "Error: tar is required to install quary."
+if ! command -v unzip >/dev/null 2>&1; then
+    echo "Error: unzip is required to install quary."
     exit 1
 fi
 
@@ -54,7 +54,7 @@ DOWNLOAD_URL=`echo $DOWNLOAD_URL | tr -d '\"'`
 curl -SL $DOWNLOAD_URL -o /tmp/$ASSET_NAME
 
 # Extract the asset
-tar -xzf /tmp/$ASSET_NAME -C /tmp
+unzip -xzf /tmp/$ASSET_NAME -C /tmp
 
 # Set the correct permissions for the binary
 chmod +x /tmp/quary


### PR DESCRIPTION
Substituted "unzip" for "tar" in the install script.

This fixes this error which I got when running the install script:

tar: This does not look like a tar archive
tar: Skipping to next header
tar: Archive contains ‘d$@I\203\304\bL’ where numeric mode_t value expected
tar: Archive contains ‘dH3\004%(\0\0\0\017\205\335’ where numeric time_t value expected
tar: Archive contains ‘9d$(\017\205\021\377’ where numeric uid_t value expected
tar: Archive value -169126968458240 is out of gid_t range 0..4294967295
tar: $PH��$�: implausibly old time stamp 1970-01-01 11:59:59
tar: Skipping to next header
tar: Exiting with failure status due to previous errors