### PR TITLE
feat: incremental model builds on cache views

### DIFF
--- a/rust/cli/src/commands.rs
+++ b/rust/cli/src/commands.rs
@@ -111,6 +111,9 @@ pub struct BuildArgs {
     #[arg(long = "cache_views", short = 'c', default_value = "false")]
     /// Build the cache views for the extension
     pub cache_views: bool,
+    #[arg(long = "incremental", short = 'i', default_value = "false")]
+    /// Update only the models or dependencies that have changed since the last build with cache, avoiding full rebuilds.
+    pub incremental: bool,
 }
 
 #[derive(Args, Debug)]


### PR DESCRIPTION
Changes:
- Improved build output
- Implement cache view builds to skip models that have not changed (and their upstream dependencies) `quary build -i`

Todo:
- Need to extend test-case to cover changing downstream model.
- As we are using CASCADE in Postgres, cache views are destroyed when a model is rebuilt. Need to create a test to check if this breaks our caching mechanism.