### PR TITLE
fix: quary not working in codespaces

### DIFF
--- a/js/packages/quary-extension/src/web/servicesContext.ts
+++ b/js/packages/quary-extension/src/web/servicesContext.ts
@@ -5,6 +5,7 @@ const HostDetailsSchema = z.object({
   hostType: z.union([
     z.literal('web'),
     z.literal('desktop'),
+    z.literal('codespaces'),
     z.literal('github.dev'),
     z.literal('vscode.dev'),
   ]),


### PR DESCRIPTION
- Update Zod schema for hostType to include 'codespaces' as an accepted value