### PR TITLE
devex: speed up tests for clickhouse

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -423,6 +423,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "autocfg"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1202,6 +1208,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "enum-as-inner"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ffccbb6966c05b32ef8fbac435df276c4ae4d3dc55a8cd0eb9745e6c12f546a"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.66",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1306,6 +1324,21 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -1553,6 +1586,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa82e28a107a8cc405f0839610bdc9b15f1e25ec7d696aa5cf173edbcb1486ab"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http 1.1.0",
+ "indexmap 2.2.6",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "half"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1617,6 +1669,51 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hickory-proto"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07698b8420e2f0d6447a436ba999ec85d8fbf2a398bbd737b82cac4a2e96e512"
+dependencies = [
+ "async-trait",
+ "cfg-if",
+ "data-encoding",
+ "enum-as-inner",
+ "futures-channel",
+ "futures-io",
+ "futures-util",
+ "idna 0.4.0",
+ "ipnet",
+ "once_cell",
+ "rand",
+ "thiserror",
+ "tinyvec",
+ "tokio",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "hickory-resolver"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28757f23aa75c98f254cf0405e6d8c25b831b32921b050a66692427679b1f243"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "hickory-proto",
+ "ipconfig",
+ "lru-cache",
+ "once_cell",
+ "parking_lot 0.12.3",
+ "rand",
+ "resolv-conf",
+ "smallvec",
+ "thiserror",
+ "tokio",
+ "tracing",
+]
 
 [[package]]
 name = "hkdf"
@@ -1740,7 +1837,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2",
+ "h2 0.3.26",
  "http 0.2.12",
  "http-body 0.4.6",
  "httparse",
@@ -1763,6 +1860,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
+ "h2 0.4.5",
  "http 1.1.0",
  "http-body 1.0.0",
  "httparse",
@@ -1835,6 +1933,22 @@ dependencies = [
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.25.0",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper 1.3.1",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
  "tower-service",
 ]
 
@@ -2022,6 +2136,16 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d20d6b07bfbc108882d88ed8e37d39636dcc260e15e30c45e6ba089610b917c"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+]
+
+[[package]]
+name = "idna"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4716a3a0933a1d01c2f72450e89596eb51dd34ef3c211ccd875acdf1f8fe47ed"
@@ -2077,6 +2201,18 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
  "web-sys",
+]
+
+[[package]]
+name = "ipconfig"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b58db92f96b720de98181bbbe63c831e87005ab460c1bf306eb2622b4707997f"
+dependencies = [
+ "socket2",
+ "widestring",
+ "windows-sys 0.48.0",
+ "winreg 0.50.0",
 ]
 
 [[package]]
@@ -2271,6 +2407,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "linked-hash-map"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2299,6 +2441,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "lru-cache"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31e24f1ad8321ca0e8a1e0ac13f23cb668e6f5466c2c57319f6a5cf1cc8e3b1c"
+dependencies = [
+ "linked-hash-map",
 ]
 
 [[package]]
@@ -2339,9 +2490,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.7.3"
+version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d0d8b92cd8358e8d229c11df9358decae64d137c5be540952c5ca7b25aea768"
+checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "mime"
@@ -2407,6 +2558,23 @@ name = "multimap"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "defc4c55412d89136f966bbb339008b474350e5e6e78d2714439c386b3137a03"
+
+[[package]]
+name = "native-tls"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8614eb2c83d59d1c8cc974dd3f920198647674a0a035e1af1fa58707e317466"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
 
 [[package]]
 name = "nom"
@@ -2586,10 +2754,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
+name = "openssl"
+version = "0.10.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95a0481286a310808298130d22dd1fef0fa571e05a8f44ec801801e84b216b1f"
+dependencies = [
+ "bitflags 2.5.0",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.66",
+]
+
+[[package]]
 name = "openssl-probe"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c597637d56fbc83893a35eb0dd04b2b8e7a50c91e64e9493e398b5df4fb45fa2"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "option-ext"
@@ -2640,7 +2846,7 @@ checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.5.1",
+ "redox_syscall 0.5.2",
  "smallvec",
  "windows-targets 0.52.5",
 ]
@@ -3135,6 +3341,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
 name = "quick-xml"
 version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3209,9 +3421,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "469052894dcb553421e483e4209ee581a45100d31b4018de03e5a7ad86374a7e"
+checksum = "c82cf8cff14456045f55ec4241383baeff27af886adb72ffb2162f99911de0fd"
 dependencies = [
  "bitflags 2.5.0",
 ]
@@ -3276,7 +3488,7 @@ dependencies = [
  "encoding_rs",
  "futures-core",
  "futures-util",
- "h2",
+ "h2 0.3.26",
  "http 0.2.12",
  "http-body 0.4.6",
  "hyper 0.14.29",
@@ -3320,16 +3532,20 @@ dependencies = [
  "encoding_rs",
  "futures-core",
  "futures-util",
+ "h2 0.4.5",
+ "hickory-resolver",
  "http 1.1.0",
  "http-body 1.0.0",
  "http-body-util",
  "hyper 1.3.1",
  "hyper-rustls 0.26.0",
+ "hyper-tls",
  "hyper-util",
  "ipnet",
  "js-sys",
  "log",
  "mime",
+ "native-tls",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
@@ -3341,6 +3557,7 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
+ "tokio-native-tls",
  "tokio-rustls 0.25.0",
  "tokio-util",
  "tower-service",
@@ -3387,6 +3604,16 @@ dependencies = [
  "tokio",
  "tracing",
  "wasm-timer",
+]
+
+[[package]]
+name = "resolv-conf"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52e44394d2086d010551b14b53b1f24e31647570cd1deb0379e2c21b329aba00"
+dependencies = [
+ "hostname",
+ "quick-error",
 ]
 
 [[package]]
@@ -4447,9 +4674,9 @@ checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
 
 [[package]]
 name = "testcontainers"
-version = "0.17.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "025e0ac563d543e0354d984540e749859a83dbe5c0afb8d458dc48d91cef2d6a"
+checksum = "a2c9b71635ab25d4f789a86678d114a4f390467c8b93fd7feeaf7c443732a511"
 dependencies = [
  "async-trait",
  "bollard",
@@ -4457,10 +4684,12 @@ dependencies = [
  "bytes",
  "dirs",
  "docker_credential",
+ "either",
  "futures",
  "log",
  "memchr",
  "parse-display",
+ "reqwest 0.12.4",
  "serde",
  "serde_json",
  "serde_with",
@@ -4473,8 +4702,9 @@ dependencies = [
 
 [[package]]
 name = "testcontainers-modules"
-version = "0.5.0"
-source = "git+https://github.com/testcontainers/testcontainers-rs-modules-community#edf3c6e940521be56edb17b4c74477f5b6a1fada"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "322fe829905e734f38a73be07e200a25713fe4baa65074277af7b30dbc4ea487"
 dependencies = [
  "testcontainers",
 ]
@@ -4594,6 +4824,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.66",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
 ]
 
 [[package]]
@@ -4793,7 +5033,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7c25da092f0a868cdf09e8674cd3b7ef3a7d92a24253e663a2fb85e2496de56"
 dependencies = [
  "form_urlencoded",
- "idna",
+ "idna 1.0.0",
  "percent-encoding",
  "serde",
 ]
@@ -5036,6 +5276,12 @@ dependencies = [
  "redox_syscall 0.4.1",
  "wasite",
 ]
+
+[[package]]
+name = "widestring"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7219d36b6eac893fa81e84ebe06485e7dcbb616177469b142df14f1f4deb1311"
 
 [[package]]
 name = "winapi"

--- a/rust/cli/Cargo.toml
+++ b/rust/cli/Cargo.toml
@@ -26,9 +26,8 @@ duckdb = { version = "0.10.2", features = ["bundled"] }
 chrono = "0.4.38"
 assert_cmd = "2"
 tempfile = "3"
-testcontainers = "0.17.0"
-# TODO make this depend on latest version when clickhouse is published
-testcontainers-modules = { git = "https://github.com/testcontainers/testcontainers-rs-modules-community", commit = "edf3c6e", features = ["postgres", "clickhouse"]}
+testcontainers = "0.18.0"
+testcontainers-modules = { version="0.6.1", features = ["postgres", "clickhouse"]}
 
 [build-dependencies]
 regex = "1.10.5"

--- a/rust/cli/tests/cli_test.rs
+++ b/rust/cli/tests/cli_test.rs
@@ -7,7 +7,7 @@ use quary_databases::databases_redshift;
 use std::fs;
 use tempfile::tempdir;
 use testcontainers::runners::AsyncRunner;
-use testcontainers::RunnableImage;
+use testcontainers::ContainerRequest;
 use testcontainers_modules::postgres::Postgres as TestcontainersPostgres;
 #[test]
 fn test_cli_in_memory() {
@@ -579,7 +579,7 @@ async fn test_redshift_snapshots() {
 #[tokio::test]
 async fn test_postgres_build_model_twice() {
     // Setup
-    let postgres = RunnableImage::from(TestcontainersPostgres::default())
+    let postgres = ContainerRequest::from(TestcontainersPostgres::default())
         .start()
         .await
         .unwrap();
@@ -643,7 +643,7 @@ async fn test_postgres_build_model_twice() {
 #[tokio::test]
 async fn test_postgres_run_tests_from_sources() {
     // Setup
-    let postgres = RunnableImage::from(TestcontainersPostgres::default())
+    let postgres = ContainerRequest::from(TestcontainersPostgres::default())
         .start()
         .await
         .unwrap();
@@ -699,7 +699,7 @@ async fn test_postgres_run_tests_from_sources() {
 #[tokio::test]
 async fn test_postgres_run_tests_from_database_tables() {
     // Setup
-    let postgres = RunnableImage::from(TestcontainersPostgres::default())
+    let postgres = ContainerRequest::from(TestcontainersPostgres::default())
         .start()
         .await
         .unwrap();

--- a/rust/quary-databases/Cargo.toml
+++ b/rust/quary-databases/Cargo.toml
@@ -27,6 +27,6 @@ futures-util = "0.3.30"
 [dev-dependencies]
 assert_cmd = "2"
 tempfile = "3"
-testcontainers = "0.17.0"
+testcontainers = "0.18.0"
 # TODO make this depend on latest version when clickhouse is published
-testcontainers-modules = { git = "https://github.com/testcontainers/testcontainers-rs-modules-community", commit = "edf3c6e", features = ["postgres", "clickhouse"]}
+testcontainers-modules = { version="0.6.1", features = ["postgres", "clickhouse"]}

--- a/rust/quary-databases/src/databases_clickhouse.rs
+++ b/rust/quary-databases/src/databases_clickhouse.rs
@@ -269,12 +269,12 @@ mod tests {
     use quary_core::project_tests::return_tests_sql;
     use quary_proto::{File, FileSystem};
     use testcontainers::runners::AsyncRunner;
-    use testcontainers::RunnableImage;
+    use testcontainers::ContainerRequest;
     use testcontainers_modules::clickhouse::ClickHouse as TestcontainersClickHouse;
 
     #[tokio::test]
     async fn test_clickhouse_list_tables_and_views() {
-        let container = RunnableImage::from(TestcontainersClickHouse::default())
+        let container = ContainerRequest::from(TestcontainersClickHouse::default())
             .start()
             .await
             .unwrap();
@@ -381,7 +381,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_clickhouse_list_columns_in_table() {
-        let container = RunnableImage::from(TestcontainersClickHouse::default())
+        let container = ContainerRequest::from(TestcontainersClickHouse::default())
             .start()
             .await
             .unwrap();
@@ -463,7 +463,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_clickhouse_foreign_relationship_test_with_schema() {
-        let container = RunnableImage::from(TestcontainersClickHouse::default())
+        let container = ContainerRequest::from(TestcontainersClickHouse::default())
             .start()
             .await
             .unwrap();
@@ -718,7 +718,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_list_tables_outside_the_schema() {
-        let container = RunnableImage::from(TestcontainersClickHouse::default())
+        let container = ContainerRequest::from(TestcontainersClickHouse::default())
             .start()
             .await
             .unwrap();
@@ -835,7 +835,7 @@ mod tests {
     // async fn test_clickhouse_snapshots_with_schema() {
     //     let schema = "analytics";
     //
-    //     let container = RunnableImage::from(TestcontainersClickHouse::default())
+    //     let container = ContainerRequest::from(TestcontainersClickHouse::default())
     //         .start()
     //         .await
     //         .unwrap();

--- a/rust/quary-databases/src/databases_postgres.rs
+++ b/rust/quary-databases/src/databases_postgres.rs
@@ -327,12 +327,12 @@ mod tests {
     use quary_proto::{File, FileSystem};
     use std::time::SystemTime;
     use testcontainers::runners::AsyncRunner;
-    use testcontainers::RunnableImage;
+    use testcontainers::ContainerRequest;
     use testcontainers_modules::postgres::Postgres as TestcontainersPostgres;
 
     #[tokio::test]
     async fn run_build_with_project_twice() {
-        let postgres = RunnableImage::from(TestcontainersPostgres::default())
+        let postgres = ContainerRequest::from(TestcontainersPostgres::default())
             .start()
             .await
             .unwrap();
@@ -402,7 +402,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_postgres_list_tables_and_views() {
-        let postgres = RunnableImage::from(TestcontainersPostgres::default())
+        let postgres = ContainerRequest::from(TestcontainersPostgres::default())
             .start()
             .await
             .unwrap();
@@ -518,7 +518,7 @@ mod tests {
 
     #[tokio::test]
     async fn list_columns_in_table() {
-        let postgres = RunnableImage::from(TestcontainersPostgres::default())
+        let postgres = ContainerRequest::from(TestcontainersPostgres::default())
             .start()
             .await
             .unwrap();
@@ -599,7 +599,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_postgres_foreign_relationship_test_with_schema() {
-        let postgres = RunnableImage::from(TestcontainersPostgres::default())
+        let postgres = ContainerRequest::from(TestcontainersPostgres::default())
             .start()
             .await
             .unwrap();
@@ -722,7 +722,7 @@ models:
 
     #[tokio::test]
     async fn test_postgres_foreign_relationship_test_with_materialized_view_table() {
-        let postgres = RunnableImage::from(TestcontainersPostgres::default())
+        let postgres = ContainerRequest::from(TestcontainersPostgres::default())
             .start()
             .await
             .unwrap();
@@ -869,7 +869,7 @@ models:
     /// postgres_sql_test tests a sql test with injecting the whole path of many models in tests
     #[tokio::test]
     async fn postgres_sql_test() {
-        let postgres = RunnableImage::from(TestcontainersPostgres::default())
+        let postgres = ContainerRequest::from(TestcontainersPostgres::default())
             .start()
             .await
             .unwrap();
@@ -1000,7 +1000,7 @@ models:
 
     #[tokio::test]
     async fn test_list_tables_outside_the_schema() {
-        let postgres = RunnableImage::from(TestcontainersPostgres::default())
+        let postgres = ContainerRequest::from(TestcontainersPostgres::default())
             .start()
             .await
             .unwrap();
@@ -1075,7 +1075,7 @@ models:
 
     #[tokio::test]
     async fn test_list_columns_with_case_sensitive_columns() {
-        let postgres = RunnableImage::from(TestcontainersPostgres::default())
+        let postgres = ContainerRequest::from(TestcontainersPostgres::default())
             .start()
             .await
             .unwrap();
@@ -1142,7 +1142,7 @@ models:
 
     #[tokio::test]
     async fn test_snapshot_with_no_time_override() {
-        let postgres = RunnableImage::from(TestcontainersPostgres::default())
+        let postgres = ContainerRequest::from(TestcontainersPostgres::default())
             .start()
             .await
             .unwrap();
@@ -1261,7 +1261,7 @@ snapshots:
 
     #[tokio::test]
     async fn test_snapshots_with_schema() {
-        let postgres = RunnableImage::from(TestcontainersPostgres::default())
+        let postgres = ContainerRequest::from(TestcontainersPostgres::default())
             .start()
             .await
             .unwrap();
@@ -1524,7 +1524,7 @@ snapshots:
     async fn test_tests_with_full_source_tree() {
         let schema = "analytics";
 
-        let postgres = RunnableImage::from(TestcontainersPostgres::default())
+        let postgres = ContainerRequest::from(TestcontainersPostgres::default())
             .start()
             .await
             .unwrap();


### PR DESCRIPTION
- uses updated testcontainers which uses http to see if can start test
  container test sooner
